### PR TITLE
Pasta をタップしたら musicPlayer がミュートになって、終了後に musicPlayer のミュートを解除するように修正

### DIFF
--- a/Pasta.xcodeproj/project.pbxproj
+++ b/Pasta.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		A599E65F2C1D43F800B29F50 /* PastaUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastaUITests.swift; sourceTree = "<group>"; };
 		A599E6612C1D43F800B29F50 /* PastaUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastaUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		A599E66E2C1D6E3D00B29F50 /* SoundPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundPlayer.swift; sourceTree = "<group>"; };
+		A599E6702C1FC49900B29F50 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +100,7 @@
 		A599E6402C1D43F600B29F50 /* Pasta */ = {
 			isa = PBXGroup;
 			children = (
+				A599E6702C1FC49900B29F50 /* Info.plist */,
 				A599E6412C1D43F600B29F50 /* PastaApp.swift */,
 				A599E6432C1D43F600B29F50 /* ContentView.swift */,
 				A599E6452C1D43F600B29F50 /* Item.swift */,
@@ -432,6 +434,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Pasta/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -470,6 +473,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Pasta/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/Pasta/ContentView.swift
+++ b/Pasta/ContentView.swift
@@ -54,7 +54,7 @@ struct ContentView: View {
             Button(action: {
                 player.pasta()
             }) {
-                Text("pasta")
+                Text("Pasta")
                     .padding(.init(top: 20, leading: 90, bottom: 20, trailing: 90))
                     .background(.green)
                     .foregroundColor(.white)

--- a/Pasta/ContentView.swift
+++ b/Pasta/ContentView.swift
@@ -9,14 +9,14 @@ import SwiftUI
 import SwiftData
 
 struct ContentView: View {
-    let musicplayer = SoundPlayer()
+    let player = SoundPlayer()
     @State private var playButton = "play"
 
     var body: some View {
         VStack {
             HStack {
                 Button(action: {
-                    musicplayer.backwardMusic()
+                    player.backwardMusic()
                 }) {
                     Image("backward")
                         .resizable()
@@ -24,7 +24,7 @@ struct ContentView: View {
                         .frame(width: 80, height: 80)
                 }
                 Button(action: {
-                    musicplayer.playMusic()
+                    player.playMusic()
                 }) {
                     Image(playButton)
                         .resizable()
@@ -32,7 +32,7 @@ struct ContentView: View {
                         .frame(width: 80, height: 80)
                 }
                 Button(action: {
-                    musicplayer.stopMusic()
+                    player.stopMusic()
                 }) {
                     Image("stop")
                         .resizable()
@@ -40,7 +40,7 @@ struct ContentView: View {
                         .frame(width: 80, height: 80)
                 }
                 Button(action: {
-                    musicplayer.forwardMusic()
+                    player.forwardMusic()
                 }) {
                     Image("forward")
                         .resizable()
@@ -52,7 +52,7 @@ struct ContentView: View {
             Spacer().frame(height: 32)
 
             Button(action: {
-                musicplayer.pasta()
+                player.pasta()
             }) {
                 Text("pasta")
                     .padding(.init(top: 20, leading: 90, bottom: 20, trailing: 90))

--- a/Pasta/Info.plist
+++ b/Pasta/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+</dict>
+</plist>

--- a/Pasta/SoundPlayer.swift
+++ b/Pasta/SoundPlayer.swift
@@ -11,14 +11,18 @@ class SoundPlayer: NSObject, AVAudioPlayerDelegate {
         super.init()
 
         do {
-            musicData = NSDataAsset(name: "full")!.data
-            pastaData = NSDataAsset(name: "pasta")!.data
-            musicPlayer = try AVAudioPlayer(data: musicData)
-            pastaPlayer = try AVAudioPlayer(data: pastaData)
-            pastaPlayer.delegate = self
-        } catch {
-            print("Load Error")
-        }
+            try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback)
+            do {
+                try AVAudioSession.sharedInstance().setActive(true)
+                musicData = NSDataAsset(name: "full")!.data
+                pastaData = NSDataAsset(name: "pasta")!.data
+                musicPlayer = try AVAudioPlayer(data: musicData)
+                pastaPlayer = try AVAudioPlayer(data: pastaData)
+                pastaPlayer.delegate = self
+            } catch {
+                print("Load Error")
+            }
+        } catch _ as NSError {}
     }
 
     func playMusic() {

--- a/Pasta/SoundPlayer.swift
+++ b/Pasta/SoundPlayer.swift
@@ -28,7 +28,7 @@ class SoundPlayer: NSObject {
 
     func stopMusic() {
         musicPlayer?.stop()
-        musicPlayer.currentTime = 0
+        musicPlayer?.currentTime = 0
     }
 
     func backwardMusic() {

--- a/Pasta/SoundPlayer.swift
+++ b/Pasta/SoundPlayer.swift
@@ -2,18 +2,24 @@ import UIKit
 import AVFoundation
 
 class SoundPlayer: NSObject {
-    let music_data = NSDataAsset(name: "full")!.data
-    let pasta_data = NSDataAsset(name: "pasta")!.data
+    var music_data: Data!
+    var pasta_data: Data!
     var music_player: AVAudioPlayer!
     var pasta_player: AVAudioPlayer!
     
-    func playMusic() {
+    override init() {
         do {
+            music_data = NSDataAsset(name: "full")!.data
+            pasta_data = NSDataAsset(name: "pasta")!.data
             music_player = try AVAudioPlayer(data: music_data)
-            music_player.play()
+            pasta_player = try AVAudioPlayer(data: pasta_data)
         } catch {
-            print("エラー発生.音を流せません")
+            print("load error")
         }
+    }
+    
+    func playMusic() {
+        music_player.play()
     }
     
     func pauseMusic() {
@@ -33,11 +39,6 @@ class SoundPlayer: NSObject {
     }
     
     func pasta() {
-        do {
-            pasta_player = try AVAudioPlayer(data: pasta_data)
-            pasta_player.play()
-        } catch {
-            print("エラー発生.音を流せません")
-        }
+        pasta_player.play()
     }
 }

--- a/Pasta/SoundPlayer.swift
+++ b/Pasta/SoundPlayer.swift
@@ -2,43 +2,43 @@ import UIKit
 import AVFoundation
 
 class SoundPlayer: NSObject {
-    var music_data: Data!
-    var pasta_data: Data!
-    var music_player: AVAudioPlayer!
-    var pasta_player: AVAudioPlayer!
+    var musicData: Data!
+    var pastaData: Data!
+    var musicPlayer: AVAudioPlayer!
+    var pastaPlayer: AVAudioPlayer!
     
     override init() {
         do {
-            music_data = NSDataAsset(name: "full")!.data
-            pasta_data = NSDataAsset(name: "pasta")!.data
-            music_player = try AVAudioPlayer(data: music_data)
-            pasta_player = try AVAudioPlayer(data: pasta_data)
+            musicData = NSDataAsset(name: "full")!.data
+            pastaData = NSDataAsset(name: "pasta")!.data
+            musicPlayer = try AVAudioPlayer(data: musicData)
+            pastaPlayer = try AVAudioPlayer(data: pastaData)
         } catch {
             print("load error")
         }
     }
     
     func playMusic() {
-        music_player.play()
+        musicPlayer.play()
     }
     
     func pauseMusic() {
-        music_player?.pause()
+        musicPlayer?.pause()
     }
     
     func stopMusic() {
-        music_player?.stop()
+        musicPlayer?.stop()
     }
     
     func backwardMusic() {
-        music_player?.currentTime -= 10
+        musicPlayer?.currentTime -= 10
     }
     
     func forwardMusic() {
-        music_player?.currentTime += 10
+        musicPlayer?.currentTime += 10
     }
     
     func pasta() {
-        pasta_player.play()
+        pastaPlayer.play()
     }
 }

--- a/Pasta/SoundPlayer.swift
+++ b/Pasta/SoundPlayer.swift
@@ -12,17 +12,15 @@ class SoundPlayer: NSObject, AVAudioPlayerDelegate {
 
         do {
             try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback)
-            do {
-                try AVAudioSession.sharedInstance().setActive(true)
-                musicData = NSDataAsset(name: "full")!.data
-                pastaData = NSDataAsset(name: "pasta")!.data
-                musicPlayer = try AVAudioPlayer(data: musicData)
-                pastaPlayer = try AVAudioPlayer(data: pastaData)
-                pastaPlayer.delegate = self
-            } catch {
-                print("Load Error")
-            }
-        } catch _ as NSError {}
+            try AVAudioSession.sharedInstance().setActive(true)
+            musicData = NSDataAsset(name: "full")!.data
+            pastaData = NSDataAsset(name: "pasta")!.data
+            musicPlayer = try AVAudioPlayer(data: musicData)
+            pastaPlayer = try AVAudioPlayer(data: pastaData)
+            pastaPlayer.delegate = self
+        } catch {
+            print("Load Error")
+        }
     }
 
     func playMusic() {

--- a/Pasta/SoundPlayer.swift
+++ b/Pasta/SoundPlayer.swift
@@ -6,7 +6,7 @@ class SoundPlayer: NSObject {
     var pastaData: Data!
     var musicPlayer: AVAudioPlayer!
     var pastaPlayer: AVAudioPlayer!
-    
+
     override init() {
         do {
             musicData = NSDataAsset(name: "full")!.data
@@ -14,30 +14,30 @@ class SoundPlayer: NSObject {
             musicPlayer = try AVAudioPlayer(data: musicData)
             pastaPlayer = try AVAudioPlayer(data: pastaData)
         } catch {
-            print("load error")
+            print("Load Error")
         }
     }
-    
+
     func playMusic() {
         musicPlayer.play()
     }
-    
+
     func pauseMusic() {
         musicPlayer?.pause()
     }
-    
+
     func stopMusic() {
         musicPlayer?.stop()
     }
-    
+
     func backwardMusic() {
         musicPlayer?.currentTime -= 10
     }
-    
+
     func forwardMusic() {
         musicPlayer?.currentTime += 10
     }
-    
+
     func pasta() {
         pastaPlayer.play()
     }

--- a/Pasta/SoundPlayer.swift
+++ b/Pasta/SoundPlayer.swift
@@ -28,6 +28,7 @@ class SoundPlayer: NSObject {
 
     func stopMusic() {
         musicPlayer?.stop()
+        musicPlayer.currentTime = 0
     }
 
     func backwardMusic() {

--- a/Pasta/SoundPlayer.swift
+++ b/Pasta/SoundPlayer.swift
@@ -1,18 +1,21 @@
 import UIKit
 import AVFoundation
 
-class SoundPlayer: NSObject {
+class SoundPlayer: NSObject, AVAudioPlayerDelegate {
     var musicData: Data!
     var pastaData: Data!
     var musicPlayer: AVAudioPlayer!
     var pastaPlayer: AVAudioPlayer!
 
     override init() {
+        super.init()
+
         do {
             musicData = NSDataAsset(name: "full")!.data
             pastaData = NSDataAsset(name: "pasta")!.data
             musicPlayer = try AVAudioPlayer(data: musicData)
             pastaPlayer = try AVAudioPlayer(data: pastaData)
+            pastaPlayer.delegate = self
         } catch {
             print("Load Error")
         }
@@ -40,6 +43,11 @@ class SoundPlayer: NSObject {
     }
 
     func pasta() {
+        musicPlayer.volume = 0
         pastaPlayer.play()
+    }
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        musicPlayer.volume = 1
     }
 }


### PR DESCRIPTION
# 対応内容

* Pasta をタップしたら musicPlayer がミュートになる
* Pasta 終了後に musicPlayer のミュートを解除する
* ミュート状態でも音が出るように設定
* バックグラウンドでも音が出るように設定

# 影響確認

* 音声ファイルの再生、停止、巻き戻し、早送りが問題なくできることを確認
* 対応内容が問題なく実行できることを確認
* 既存機能に影響がないことを確認